### PR TITLE
Make jshint happy about the basic layout of QUnit tests

### DIFF
--- a/includes/twig/templates/.jshintrc.twig
+++ b/includes/twig/templates/.jshintrc.twig
@@ -1,4 +1,10 @@
 {
+	"predef": [
+		"mediaWiki",
+		"jQuery",
+		"QUnit"
+	],
+
 	// Enforcing
 	"bitwise": true,
 	"eqeqeq": true,


### PR DESCRIPTION
Makes jshint recognize `QUnit`, `mediaWiki` and `jQuery` thereby fixing most but not all of #49 .

I couldn't figure out a good heading and didn't in particular consider the order of these in the file.
