### PR TITLE
package.json: Use valid spdx identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "MWStew",
   "author": "Moriel Schottlender",
-  "license": "GPLv2.0",
+  "license": "GPL-2.0",
   "version": "1.0.0",
   "description": "A boilerplate maker for MediaWiki extensions",
   "repository": {


### PR DESCRIPTION
npm WARN package.json MWStew@1.0.0 license should be a valid SPDX license expression
