### PR TITLE
Add dev dependency on grunt-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
     "grunt-contrib-csslint": "1.0.0",
     "grunt-contrib-less": "*",
     "grunt-cssjanus": "*",


### PR DESCRIPTION
So you don't need a global install of grunt to build the project.
